### PR TITLE
Support plugin setup via VimL

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,5 +90,31 @@ require("neocord").setup({
 })
 ```
 
+### VimL
+While the plugin is written in pure Lua, it can still be initialized using standard Vim commands (i.e. if you have an `init.vim` instead of `init.lua`).
+The available config options are as shown above; we just need to use some special Vim syntax around them:
+```vim
+call v:lua.require'neocord'.setup_no_return(#{
+    \ logo: 'auto',
+    \ })
+```
+Vim does not support null variables very well, so passing a value equivalent to `nil` does not seem to be possible with this method.
+To set an option to `nil`, use the syntax below, or refrain from setting that option explicitly (if its default is `nil`).
+
+Alternatively, use a Lua heredoc.
+This is slightly more verbose, but supports all Lua syntax.
+For example:
+```vim
+if has('nvim-0.5') || has('lua') 
+    lua << EOF
+    require('neocord').setup({
+        logo         = "auto",
+        logo_tooltip = nil,
+        -- etc...
+    })
+EOF
+endif
+```
+
 ## Special Thanks:
 - [vscord](https://github.com/leonardssh/vscord) for the [icons](https://github.com/leonardssh/vscord/tree/main/assets/icons).

--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -132,6 +132,13 @@ function neocord:setup(...)
   return self
 end
 
+-- Helper function for setup from VimL call. Suppresses setup()'s
+-- return value, since it can't be translated to a native VimL object.
+function neocord.setup_no_return(options)
+  neocord.setup(options)
+  return nil
+end
+
 -- Normalize the OS name from uname
 function neocord.get_os_name(uname)
   if uname.sysname:find("Windows") then


### PR DESCRIPTION
## Description of changes

- Added a wrapper function around `setup()`, which suppresses its return value. This allows the wrapper function to be called from VimL. See #2 for details.
- Added documentation for plugin setup using VimL.

## Relevant Issues

#2

## CC Maintainers

@IogaMaster
