### PR TITLE
Fix reading status never being shown

### DIFF
--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -415,18 +415,20 @@ function neocord:get_status_text(filename)
     return nil
   end
 
-  if string.find(vim.bo.filetype, "git") then
-    return self:format_status_text("git_commit", filename)
-  elseif filename then
-    return self:format_status_text("editing", filename)
-  end
-
   if vim.bo.readonly then
     return self:format_status_text("reading", filename)
   end
 
   if terminal then
     return self:format_status_text("terminal", terminal)
+  end
+
+  if string.find(vim.bo.filetype, "git") then
+    return self:format_status_text("git_commit", filename)
+  end
+
+  if filename then
+    return self:format_status_text("editing", filename)
   end
 end
 


### PR DESCRIPTION
## Description of changes

Fix the reading status never being shown by moving it further up in
`init.lua:neocord:get_status_text()`.

When opening any file with `readonly` or `nomodifiable` set, Neocord
will (incorrectly) report that one is "editing" said file, when it
should be set to "reading" instead.

Neocord already returns `nil` early when no filename was set. However,
it also returns early relative to where the "reading" text would be set
whenever a filename *is* present, making that part unreachable.

This patch simply moves some if-statements around, making sure "editing"
is the *very last* "option" for an open buffer.

## Relevant Issues

#4

## CC Maintainers

@IogaMaster

---
P.S. Viewing the commit body may be a bit easier, since I actually
format my commit messages. Still tried my best to adhere to your template.
