### PR TITLE
Add global_timer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,16 @@ Require the plugin and call `setup` with a config table with one or more of the 
 -- The setup config table shows all available config options with their default values:
 require("neocord").setup({
     -- General options
-    logo                = "auto", -- "auto" or url
-    logo_tooltip        = nil, -- nil or string
-    main_image          = "language" -- "language" or "logo"
-    client_id           = "1157438221865717891",       -- Use your own Discord application client id (not recommended)
+    logo                = "auto",                     -- "auto" or url
+    logo_tooltip        = nil,                        -- nil or string
+    main_image          = "language"                  -- "language" or "logo"
+    client_id           = "1157438221865717891",      -- Use your own Discord application client id (not recommended)
     log_level           = nil,                        -- Log messages at or above this level (one of the following: "debug", "info", "warn", "error")
     debounce_timeout    = 10,                         -- Number of seconds to debounce events (or calls to `:lua package.loaded.presence:update(<filename>, true)`)
     blacklist           = {},                         -- A list of strings or Lua patterns that disable Rich Presence if the current file name, path, or workspace matches
     file_assets         = {},                         -- Custom file asset definitions keyed by file names and extensions (see default config at `lua/presence/file_assets.lua` for reference)
     show_time           = true,                       -- Show the timer
+    global_timer         = false,                     -- if set true, timer won't update when any event are triggered
 
     -- Rich Presence text options
     editing_text        = "Editing %s",               -- Format string rendered when an editable file is loaded in the buffer (either string or function(filename: string): string)

--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -19,6 +19,8 @@ local dashboards = require("neocord.filetypes.dashboards")
 local Discord = require("lib.discord")
 local utils = require("neocord.utils")
 
+local global_start = os.time()
+
 function neocord:setup(...)
   -- Support setup invocation via both dot and colon syntax.
   -- To maintain backwards compatibility, colon syntax will still
@@ -82,6 +84,7 @@ function neocord:setup(...)
   utils.set_option(self, "terminal_text", "Using terminal")
   utils.set_option(self, "line_number_text", "Line %s out of %s")
   utils.set_option(self, "show_time", true)
+  utils.set_option(self, "global_timer", false)
   utils.set_option(self, "file_assets", {})
   for name, asset in pairs(default_file_assets) do
     if not self.options.file_assets[name] then
@@ -736,10 +739,10 @@ function neocord:update_for_buffer(buffer, should_debounce)
     return
   end
 
-  local activity_set_at = os.time()
+  local activity_set_at = self.options.global_timer == 1 and global_start or os.time()
   -- If we shouldn't debounce and we trigger an activity, keep this value the same.
   -- Otherwise set it to the current time.
-  local relative_activity_set_at = should_debounce and self.last_activity.relative_set_at or os.time()
+  local relative_activity_set_at = self.options.global_timer == 1 and global_start or should_debounce and self.last_activity.relative_set_at or os.time()
 
   self.log:debug(string.format("Setting activity for %s...", buffer and #buffer > 0 and buffer or "unnamed buffer"))
 


### PR DESCRIPTION
Most of the time, I just want discord presence to show how long I've been using neovim in total, not how long I've been in a buffer or doing something. When I was actively editing and switching files, the timer rarely touched 10 seconds. This PR addresses that.