### PR TITLE
Support for an "idling" state after a set duration

### DIFF
--- a/autoload/neocord.vim
+++ b/autoload/neocord.vim
@@ -11,6 +11,8 @@ function neocord#SetAutoCmds()
             autocmd BufEnter * lua package.loaded.neocord:handle_buf_enter()
             autocmd BufAdd * lua package.loaded.neocord:handle_buf_add()
             autocmd UIEnter * lua package.loaded.neocord:handle_ui_enter()
+            autocmd CursorMoved * lua package.loaded.neocord:handle_cursor_moved()
+            autocmd CursorMovedI * lua package.loaded.neocord:handle_cursor_moved()
         endif
     augroup END
 endfunction

--- a/autoload/neocord.vim
+++ b/autoload/neocord.vim
@@ -13,6 +13,8 @@ function neocord#SetAutoCmds()
             autocmd UIEnter * lua package.loaded.neocord:handle_ui_enter()
             autocmd CursorMoved * lua package.loaded.neocord:handle_cursor_moved()
             autocmd CursorMovedI * lua package.loaded.neocord:handle_cursor_moved()
+            autocmd TermEnter * lua package.loaded.neocord:handle_term_enter()
+            autocmd TermLeave * lua package.loaded.neocord:handle_term_leave()
         endif
     augroup END
 endfunction

--- a/lua/neocord/filetypes/file_assets.lua
+++ b/lua/neocord/filetypes/file_assets.lua
@@ -43,6 +43,7 @@ return {
   html = { "HTML", "html" },
   hx = { "Haxe", "haxe" },
   hxx = { "C++ header file", "cpp" },
+  idle = { "Idle", "idle" },
   ini = { "Configuration file", "config" },
   ino = { "Arduino", "arduino" },
   ipynb = { "Jupyter Notebook", "jupyter" },

--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -3,6 +3,7 @@ neocord.is_authorized = false
 neocord.is_authorizing = false
 neocord.is_connected = false
 neocord.is_connecting = false
+neocord.is_idling = false
 neocord.last_activity = {}
 neocord.peers = {}
 neocord.socket = vim.v.servername
@@ -961,7 +962,6 @@ function neocord:cancel_idle_timer()
   self.idle_timer = nil
   if self.is_idling then
     self.is_idling = false
-    self.exit_idle = true
     global_start = os.time()
     self:update()
   end


### PR DESCRIPTION
## Description of changes

Other VSCode discord rich presence plugins can detect and show an "idling" status, which neocord (and presence.nvim) lacked. Friends joke that I am on neovim for 20 hours, but that's only because I leave my machine turned on constantly and don't close my nvim sessions.

This PR allows options to tweak the duration before neocord reports an idling status (`idle_timeout`), and to allow whether to show this idling status on discord (modifiable with option `idling_text`) or completely remove any activity once idling (`show_idle`).

This works by attaching handlers to the `CursorMoved` and `CursorMovedI` events. This does not pick up changes within the terminal, though (and I am a heavy user of toggleterm.nvim), so I halted the internal idling timer on `TermEnter`.

This PR also indirectly fixes the `global_timer` option to work properly within workspaces so that the timer will reset for each new buffer entered when `global_timer = false`. For some reason, the behavior of neocord was the exact same regardless of the option setting unless I'm on my own changes.

## Relevant Issues

This was a WIP feature from presence.nvim before that project became lowkey stale: https://github.com/andweeb/presence.nvim/projects/1#card-60538677, https://github.com/andweeb/presence.nvim/issues/40. I based my implementation off from the half-baked code, though it's my first time working deeply with Lua, let alone nvim plugins 😅.