### PR TITLE
avoid problem when response is nil

### DIFF
--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -280,7 +280,7 @@ function neocord:authorize(on_done)
       return
     end
 
-    self.log:info(string.format("Authorized with Discord for %s", response.data.user.username))
+    self.log:info(string.format("Authorized with Discord")) -- for %s", response.data.user.username))
     self.is_authorized = true
 
     if on_done then


### PR DESCRIPTION
## Description of change
Just changed line 283 to avoid the problem that happens when the response is `nil` in the issue #16