### PR TITLE
Use correct path separator for Fugitive

### DIFF
--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -383,7 +383,7 @@ function neocord.get_filename(path, path_separator)
   -- so i just remove them.
   -- sample path: fugitive:///path/to/.git//
 
-  if path:sub(-2, -1) == "//" then
+  if path:sub(-2, -1) == string.rep(path_separator, 2) then
     path = path:sub(0, -3)
   end
   return path:match(string.format("^.+%s(.+)$", path_separator))


### PR DESCRIPTION
## Description of changes

<!-- What changes did you make -->
Changed hard-coded `"//"` to use the correct file separator when removing the end of a Fugitive path, previously threw an error on Windows due to blank file name.