### PR TITLE
Fix workspaces on Windows

### DIFF
--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -348,7 +348,11 @@ function neocord:get_project_name(file_path)
   -- TODO: Only checks for a git repository, could add more checks here
   -- Might want to run this in a background process depending on performance
   local project_path_cmd = "git rev-parse --show-toplevel"
-  project_path_cmd = string.format([[bash -c 'cd "%s" && %s']], file_path, project_path_cmd)
+  if self.os.name == "windows" then
+    project_path_cmd = string.format([[cmd /c "cd "%s" && %s"]], file_path, project_path_cmd)
+  else
+    project_path_cmd = string.format([[bash -c 'cd "%s" && %s']], file_path, project_path_cmd)
+  end
 
   local project_path = vim.fn.system(project_path_cmd)
   project_path = vim.trim(project_path)

--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -348,8 +348,7 @@ function neocord:get_project_name(file_path)
   -- TODO: Only checks for a git repository, could add more checks here
   -- Might want to run this in a background process depending on performance
   local project_path_cmd = "git rev-parse --show-toplevel"
-  project_path_cmd = file_path and string.format([[bash -c 'cd "%s" && %s']], file_path, project_path_cmd)
-    or project_path_cmd
+  project_path_cmd = string.format([[bash -c 'cd "%s" && %s']], file_path, project_path_cmd)
 
   local project_path = vim.fn.system(project_path_cmd)
   project_path = vim.trim(project_path)


### PR DESCRIPTION
## Description of changes

Previously workspaces would never display on Windows because it would attempt to call bash in order to retrieve the workspace name rather than cmd. I removed the check for `file_path` since there is already a check for it earlier which returns the function early.