### PR TITLE
Show project name when editing COMMIT_EDITMSG

### DIFF
--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -342,16 +342,13 @@ function neocord:get_project_name(file_path)
     return nil
   end
 
-  -- Escape quotes in the file path
-  file_path = file_path:gsub([["]], [[\"]])
-
   -- TODO: Only checks for a git repository, could add more checks here
   -- Might want to run this in a background process depending on performance
   local project_path_cmd = "git rev-parse --show-toplevel"
   if self.os.name == "windows" then
-    project_path_cmd = string.format([[cmd /c "cd "%s" && %s"]], file_path, project_path_cmd)
+    project_path_cmd = string.format([[cmd /c "%s"]], project_path_cmd)
   else
-    project_path_cmd = string.format([[bash -c 'cd "%s" && %s']], file_path, project_path_cmd)
+    project_path_cmd = string.format([[bash -c '%s']], project_path_cmd)
   end
 
   local project_path = vim.fn.system(project_path_cmd)


### PR DESCRIPTION
## Description of changes

Show the project name when editing a COMMIT_EDITMSG file. Formerly, we
changed the working directory to the path of the file being edited,
which is undesirable when committing changes on a project tracked in Git.

## Relevant Issues

N/A

## CC Maintainers

@IogaMaster


----

Addendum:

I'm not sure if this change is also desirable—I'm fine with maintaining
my own patchset if it isn't accepted by the general userbase.
There's still a warning emitted by luacheck, but it isn't relevant to
this change, therefore I didn't bother to fix it, though it seems to be
rather trivial.
