### PR TITLE
Use `vim.system(...)` instead of `vim.fn.system(...)`

### DIFF
--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -661,13 +661,21 @@ function neocord:get_buttons(buffer, parent_dirpath)
   -- Retrieve the git repository URL
   local repo_url
   if parent_dirpath then
-    -- Escape quotes in the file path
-    local path = parent_dirpath:gsub([["]], [[\"]])
-    local git_url_cmd = "git config --get remote.origin.url"
-    local cmd = path and string.format([[cd "%s" && %s]], path, git_url_cmd) or git_url_cmd
+    local git_url_cmd = { "git", "config", "--get", "remote.origin.url" }
+    local ok, res = pcall(function()
+      return vim
+        .system(git_url_cmd, {
+          cwd = parent_dirpath,
+          text = true,
+        })
+        :wait()
+    end)
+    if not ok or res.code ~= 0 then
+      return nil
+    end
 
     -- Trim and coerce empty string value to null
-    repo_url = vim.trim(vim.fn.system(cmd))
+    repo_url = vim.trim(res.stdout)
     repo_url = repo_url ~= "" and repo_url or nil
   end
 


### PR DESCRIPTION
## Description of changes

Essentially just replaced the `vim.fn.system` calls with improved [`vim.system`](https://neovim.io/doc/user/lua.html#vim.system()) calls.

The motivating reason was that (for a reason unbeknownst to me) `vim.system` calls cause the cursor to start blinking when running neovim specifically in the kitty terminal (works fine in xterm).

However, this also simplifies the code as it now bypasses the shell so should be entirely cross-platform and should not have any quoting issues. Although now `vim.system` errors if `git` isn't available so some extra error handling is required. I've only ever used lua in neovim snippets up until now so let me know if anything should have been done different.

Also it looks like `neocord:get_buttons` is unused but I changed the call there too in a different commit just for completeness.

## Relevant Issues

None

## CC Maintainers

@IogaMaster
