### PR TITLE
fix(logger): use correct default for log_level

### DIFF
--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -36,7 +36,7 @@ function neocord:setup(...)
   self.options = options
 
   -- Initialize logger
-  utils.set_option(self, "log_level", "error", false)
+  utils.set_option(self, "log_level", nil, false)
   self.log = log:init({ level = options.log_level })
 
   -- Get operating system information including path separator


### PR DESCRIPTION
## Description of changes

This PR changes the default `log_level` to the one described in the readme. It's advertised as `nil` but when reviewing `init.lua` I discovered the default was actually `error`.

This wasn't ideal since there is no way to pass `nil` as an override in your config, since it just gets replaced by the default anyway.

## Relevant Issues

This resolves #29 

## CC Maintainers

@IogaMaster 
