### PR TITLE
Recognize .hh files as C++ header files

### DIFF
--- a/lua/neocord/filetypes/file_assets.lua
+++ b/lua/neocord/filetypes/file_assets.lua
@@ -45,6 +45,7 @@ return {
   gvy = { "Groovy", "groovy" },
   gy = { "Groovy", "groovy" },
   h = { "C header file", "c" },
+  hh = { "C++ header file", "cpp" },
   hpp = { "C++ header file", "cpp" },
   hs = { "Haskell", "haskell" },
   html = { "HTML", "html" },


### PR DESCRIPTION
## Description of changes

<!-- What changes did you make -->
Changed to recognize .hh as C++ header files, as it was not previously recognized.

## Relevant Issues

<!-- Eg. #43 -->
None

## CC Maintainers

<!-- Most of the time it will be IogaMaster -->
@IogaMaster 
