### PR TITLE
feat: enable buttons for buffer activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ require("neocord").setup({
     file_assets         = {},                         -- Custom file asset definitions keyed by file names and extensions (see default config at `lua/presence/file_assets.lua` for reference)
     show_time           = true,                       -- Show the timer
     global_timer        = false,                      -- if set true, timer won't update when any event are triggered
+    buttons             = nil,                        -- A list of buttons (objects with label and url attributes) or a function returning such list.
 
     -- Rich Presence text options
     editing_text        = "Editing %s",               -- Format string rendered when an editable file is loaded in the buffer (either string or function(filename: string): string)

--- a/lua/neocord/init.lua
+++ b/lua/neocord/init.lua
@@ -802,12 +802,15 @@ function neocord:update_for_buffer(buffer, should_debounce)
     small_text = use_language_as_main_image and distro_text or file_text,
   }
 
+  local buttons = self:get_buttons(buffer, parent_dirpath)
+
   local activity = {
     state = status_text,
     assets = assets,
     timestamps = self.options.show_time == 1 and {
       start = relative_activity_set_at,
     } or nil,
+    buttons = buttons or nil,
   }
 
   -- Get the current line number and line count if the user has set the enable_line_number option


### PR DESCRIPTION
## Description of changes

Neocord's source code already contains a solid function for creating buttons for the discord activity.
However, this function has never been called. So this PR incorporates the default "View Repository" or any custom button specified in `opts.buttons` to the discord activity blade.

## Relevant Issues
None open

## CC Maintainers
logaMaster
<!-- Most of the time it will be IogaMaster -->
