### PR TITLE
fix: fix error spam when used with firenvim

### DIFF
--- a/lua/neocord/utils.lua
+++ b/lua/neocord/utils.lua
@@ -18,7 +18,7 @@ end
 
 function utils.get_gui_info()
   local info = vim.api.nvim_get_chan_info(1).client
-  if info.type == "ui" then
+  if info ~= nil and info.type == "ui" then
     return info.name
   end
   return nil


### PR DESCRIPTION
## Description of changes

originally, trying to run an embedded instance of neovim with neocord (with the `firenvim` extension in particular) would result in an error spam stating that `info` in `utils.get_gui_info()` was nil. This PR simpily adds a nil check before accessing `info.type`.
https://github.com/IogaMaster/neocord/blob/41bacd44e9d36f5e36e0271672ac2c02f6fa355a/lua/neocord/utils.lua#L19-L25

## Relevant Issues

None

## CC Maintainers

@IogaMaster
